### PR TITLE
refactor public APIs to require a context.Context for Lock() and having an explicit TryLock()

### DIFF
--- a/dlock.go
+++ b/dlock.go
@@ -6,11 +6,12 @@ package dlock
 
 import (
 	"context"
-	"errors"
+
 	"sync"
 	"time"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -50,39 +51,11 @@ type DLock struct {
 	// key to lock for.
 	key string
 
-	// defaultOptions are overwritten by call to Lock() or RLock().
-	defaultOptions []Option
-
 	// refreshCancel stops refreshing lock's TTL.
 	refreshCancel context.CancelFunc
 
 	// refreshWait is a waiter to make sure refreshing is finished.
 	refreshWait *sync.WaitGroup
-}
-
-// configuration keeps lock configurations.
-type configuration struct {
-	ctx               context.Context
-	obtainImmediately bool
-}
-
-// Option modifies configuration.
-type Option func(*configuration)
-
-// ContextOption provides a context to locking. when ctx is cancelled,
-// Lock() will stop blocking and return with error.
-func ContextOption(ctx context.Context) Option {
-	return func(c *configuration) {
-		c.ctx = ctx
-	}
-}
-
-// ObtainImmediatelyOption tries to Lock() immediately.
-// if cannot, Lock() will return with an error.
-func ObtainImmediatelyOption() Option {
-	return func(c *configuration) {
-		c.obtainImmediately = true
-	}
 }
 
 // New creates a new distributed lock for key on given store with options.
@@ -91,55 +64,58 @@ func ObtainImmediatelyOption() Option {
 // as an equivalent of,
 //   `var m sync.Mutex`
 // and use it in the same way.
-func New(key string, store Store, options ...Option) *DLock {
-	d := &DLock{
-		key:            buildKey(key),
-		defaultOptions: options,
-		store:          store,
+func New(key string, store Store) *DLock {
+	return &DLock{
+		key:   buildKey(key),
+		store: store,
 	}
-	return d
-}
-
-// createConfig creates a new config by merging options with default ones.
-func (d *DLock) createConfig(options ...Option) *configuration {
-	c := &configuration{}
-	options = append(d.defaultOptions, options...)
-	for _, o := range options {
-		o(c)
-	}
-	if c.ctx == nil {
-		c.ctx = context.Background()
-	}
-	return c
 }
 
 // Lock obtains a new lock.
+// ctx provides a context to locking. when ctx is cancelled, Lock() will stop
+// blocking and retries and return with error.
 // use Lock() exactly like sync.Mutex.Lock(), avoid missuses like deadlocks.
-func (d *DLock) Lock(options ...Option) error {
+func (d *DLock) Lock(ctx context.Context) error {
+	for {
+		isLockObtained, err := d.lock()
+		if err != nil {
+			return err
+		}
+		if isLockObtained {
+			return nil
+		}
+		afterC := time.After(lockTryInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-afterC:
+		}
+	}
+}
+
+// TryLock tries to obtain the lock immediately.
+// err is only filled on system failure.
+func (d *DLock) TryLock() (isLockObtained bool, err error) {
+	return d.lock()
+}
+
+// lock obtains a new lock and starts refreshing the lock until a call to
+// Unlock() to not hit lock's TTL.
+func (d *DLock) lock() (isLockObtained bool, err error) {
 	kopts := model.PluginKVSetOptions{
 		EncodeJSON:      true,
 		Atomic:          true,
 		OldValue:        nil,
 		ExpireInSeconds: int64(lockTTL.Seconds()),
 	}
-	conf := d.createConfig(options...)
-	for {
-		_, aerr := d.store.KVSetWithOptions(d.key, true, kopts)
-		isLockObtained := aerr == nil
-		if isLockObtained {
-			d.startRefreshLoop()
-			return nil
-		}
-		if conf.obtainImmediately {
-			return ErrCouldntObtainImmediately
-		}
-		afterC := time.After(lockTryInterval)
-		select {
-		case <-conf.ctx.Done():
-			return conf.ctx.Err()
-		case <-afterC:
-		}
+	isLockObtained, aerr := d.store.KVSetWithOptions(d.key, true, kopts)
+	if aerr != nil {
+		return false, errors.Wrap(aerr, "KVSetWithOptions() error, cannot lock")
 	}
+	if isLockObtained {
+		d.startRefreshLoop()
+	}
+	return isLockObtained, nil
 }
 
 // startRefreshLoop refreshes an obtained lock to not get caught by lock's TTL.
@@ -177,7 +153,7 @@ func (d *DLock) Unlock() error {
 	return normalizeAppErr(aerr)
 }
 
-func (d *DLock) RLock(options ...Option) error { panic("unimplemented") }
+func (d *DLock) RLock(ctx context.Context) error { panic("unimplemented") }
 
 func (d *DLock) RUnlock() error { panic("unimplemented") }
 

--- a/dlock_test.go
+++ b/dlock_test.go
@@ -1,6 +1,7 @@
 package dlock
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func TestLock(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 10; i++ {
-				dl.Lock()
+				dl.Lock(context.Background())
 				time.Sleep(100 * time.Microsecond)
 				dl.Unlock()
 			}
@@ -29,18 +30,19 @@ func TestLock(t *testing.T) {
 	wg.Wait()
 }
 
-func TestLockObtainImmediately(t *testing.T) {
+func TestTryLock(t *testing.T) {
 	dl := New("a", dlocktest.NewStore())
-	dl.Lock()
-	err := dl.Lock(ObtainImmediatelyOption())
-	require.Equal(t, ErrCouldntObtainImmediately, err)
+	dl.Lock(context.Background())
+	isLockObtained, err := dl.TryLock()
+	require.NoError(t, err)
+	require.False(t, isLockObtained)
 }
 
 func TestLockDifferentKeys(t *testing.T) {
 	dla := New("a", dlocktest.NewStore())
 	dlb := New("b", dlocktest.NewStore())
-	dla.Lock()
-	dlb.Lock()
+	dla.Lock(context.Background())
+	dlb.Lock(context.Background())
 	dla.Unlock()
 	dlb.Unlock()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/mattermost/mattermost-server v0.0.0-20191107143132-540cfb0239df
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 )


### PR DESCRIPTION
* these changes removes the Option API since it's not needed anymore.

* fixes a part of #1.

--
* depends on https://github.com/ilgooz/mattermost-dlock/pull/2 to be merged first.

--
@lieut-data can you please review? Thanks!